### PR TITLE
Added StopAtTag and ReturnTags options when reading data set

### DIFF
--- a/dicom.go
+++ b/dicom.go
@@ -41,7 +41,9 @@ func doassert(cond bool, values ...interface{}) {
 // ReadOptions defines how DataSets and Elements are parsed.
 type ReadOptions struct {
 	// If true, skip the PixelData element (bulk images) in ReadDataSet.
-	DropPixelData bool
+	DropPixelData 	bool
+	ReturnTags 		[]dicomtag.Tag
+	StopAtTag 		*dicomtag.Tag
 }
 
 // ReadDataSetInBytes is a shorthand for ReadDataSet(bytes.NewBuffer(data), len(data)).
@@ -113,7 +115,9 @@ func ReadDataSet(in io.Reader, bytes int64, options ReadOptions) (*DataSet, erro
 				}
 			}
 		}
-		file.Elements = append(file.Elements, elem)
+		if options.ReturnTags != nil && tagInList(elem.Tag, options.ReturnTags) {
+			file.Elements = append(file.Elements, elem)
+		}
 	}
 	return file, buffer.Error()
 }

--- a/dicom.go
+++ b/dicom.go
@@ -114,7 +114,7 @@ func ReadDataSet(in io.Reader, bytes int64, options ReadOptions) (*DataSet, erro
 				}
 			}
 		}
-		if options.ReturnTags != nil && tagInList(elem.Tag, options.ReturnTags) {
+		if options.ReturnTags == nil || (options.ReturnTags != nil && tagInList(elem.Tag, options.ReturnTags)) {
 			file.Elements = append(file.Elements, elem)
 		}
 	}

--- a/dicom.go
+++ b/dicom.go
@@ -40,10 +40,9 @@ func doassert(cond bool, values ...interface{}) {
 
 // ReadOptions defines how DataSets and Elements are parsed.
 type ReadOptions struct {
-	// If true, skip the PixelData element (bulk images) in ReadDataSet.
-	DropPixelData 	bool
-	ReturnTags 		[]dicomtag.Tag
-	StopAtTag 		*dicomtag.Tag
+	DropPixelData 	bool				// If true, skip the PixelData element (bulk images) in ReadDataSet.
+	ReturnTags 		[]dicomtag.Tag 		// A list of tags, when not nil, will whitelist which tags to return
+	StopAtTag 		*dicomtag.Tag 		// A tag at which when read (or a tag with a greater value than it is read), the program will stop parsing the dicom file
 }
 
 // ReadDataSetInBytes is a shorthand for ReadDataSet(bytes.NewBuffer(data), len(data)).

--- a/dicom_test.go
+++ b/dicom_test.go
@@ -145,7 +145,7 @@ func TestReadOptions(t *testing.T) {
  	}
 
  	// Test Stop at Tag
- 	data = mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, StopAtTag: dicomtag.StudyInstanceUID}) // Study Instance UID Element tag is Tag{0x0020, 0x000D}
+ 	data = mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, StopAtTag: &dicomtag.StudyInstanceUID}) // Study Instance UID Element tag is Tag{0x0020, 0x000D}
  	_, err = data.FindElementByTag(dicomtag.PatientName) // Patient Name Element tag is Tag{0x0010, 0x0010}
  	if err != nil {
 		t.Error(err)

--- a/dicom_test.go
+++ b/dicom_test.go
@@ -120,40 +120,40 @@ func TestReadDataSet(t *testing.T) {
 	}
 }
 
-// Test ReadOptions.DropPixelData.
+// Test ReadOptions
 func TestReadOptions(t *testing.T) {
-	// Test Drop Pixel Data
-	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true})
-	_, err := data.FindElementByTag(dicomtag.PatientName)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = data.FindElementByTag(dicomtag.PixelData)
-	if err == nil {
-		t.Errorf("PixelData should not be present")
-	}
+ 	// Test Drop Pixel Data
+  	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true})
+  	_, err := data.FindElementByTag(dicomtag.PatientName)
+  	if err != nil {
+ 		t.Error(err)
+ 	}
+ 	_, err = data.FindElementByTag(dicomtag.PixelData)
+  	if err == nil {
+  		t.Errorf("PixelData should not be present")
+  	}
 
-	// Test Return Tags
-	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, ReturnTags: [dicomtag.StudyInstanceUID]})
-	_, err := data.FindElementByTag(dicomtag.StudyInstanceUID)
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = data.FindElementByTag(dicomtag.PatientName)
-	if err == nil {
-		t.Errorf("PatientName should not be present")
-	}
+ 	// Test Return Tags
+ 	data = mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, ReturnTags: []dicomtag.Tag{dicomtag.StudyInstanceUID}})
+ 	_, err = data.FindElementByTag(dicomtag.StudyInstanceUID)
+ 	if err != nil {
+ 		t.Error(err)
+ 	}
+ 	_, err = data.FindElementByTag(dicomtag.PatientName)
+ 	if err == nil {
+ 		t.Errorf("PatientName should not be present")
+ 	}
 
-	// Test Stop at Tag
-	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, StopAtTags: dicomtag.StudyInstanceUID}) // Study Instance UID Element tag is Tag{0x0020, 0x000D}
-	_, err = data.FindElementByTag(dicomtag.PatientName) // Patient Name Element tag is Tag{0x0010, 0x0010}
-	if err != nil {
+ 	// Test Stop at Tag
+ 	data = mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, StopAtTag: dicomtag.StudyInstanceUID}) // Study Instance UID Element tag is Tag{0x0020, 0x000D}
+ 	_, err = data.FindElementByTag(dicomtag.PatientName) // Patient Name Element tag is Tag{0x0010, 0x0010}
+ 	if err != nil {
 		t.Error(err)
-	}
-	_, err := data.FindElementByTag(dicomtag.SeriesInstanceUID) // Series Instance UID Element tag is Tag{0x0020, 0x000E}
-	if err == nil {
-		t.Errorf("PatientName should not be present")
-	}
+ 	}
+ 	_, err = data.FindElementByTag(dicomtag.SeriesInstanceUID) // Series Instance UID Element tag is Tag{0x0020, 0x000E}
+ 	if err == nil {
+ 		t.Errorf("PatientName should not be present")
+ 	}
 }
 
 func BenchmarkParseSingle(b *testing.B) {

--- a/dicom_test.go
+++ b/dicom_test.go
@@ -121,7 +121,8 @@ func TestReadDataSet(t *testing.T) {
 }
 
 // Test ReadOptions.DropPixelData.
-func TestDropPixelData(t *testing.T) {
+func TestReadOptions(t *testing.T) {
+	// Test Drop Pixel Data
 	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true})
 	_, err := data.FindElementByTag(dicomtag.PatientName)
 	if err != nil {
@@ -130,6 +131,28 @@ func TestDropPixelData(t *testing.T) {
 	_, err = data.FindElementByTag(dicomtag.PixelData)
 	if err == nil {
 		t.Errorf("PixelData should not be present")
+	}
+
+	// Test Return Tags
+	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, ReturnTags: [dicomtag.StudyInstanceUID]})
+	_, err := data.FindElementByTag(dicomtag.StudyInstanceUID)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = data.FindElementByTag(dicomtag.PatientName)
+	if err == nil {
+		t.Errorf("PatientName should not be present")
+	}
+
+	// Test Stop at Tag
+	data := mustReadFile("examples/IM-0001-0001.dcm", dicom.ReadOptions{DropPixelData: true, StopAtTags: dicomtag.StudyInstanceUID}) // Study Instance UID Element tag is Tag{0x0020, 0x000D}
+	_, err = data.FindElementByTag(dicomtag.PatientName) // Patient Name Element tag is Tag{0x0010, 0x0010}
+	if err != nil {
+		t.Error(err)
+	}
+	_, err := data.FindElementByTag(dicomtag.SeriesInstanceUID) // Series Instance UID Element tag is Tag{0x0020, 0x000E}
+	if err == nil {
+		t.Errorf("PatientName should not be present")
 	}
 }
 


### PR DESCRIPTION
Hey, I've been using this new fork of the go-dicom library and found some useful options that I've found help with memory usage when reading large amounts of dicom files.
- `ReadOptions.ReturnTags` 
  - Allows users to send a list of tags that they want exclusively to be returned in DataSet.Elements
  - If it is nil, it will return all tags (other than the ones with tag values greater than the StopAtTag)
- `ReadOptions.StopAtTag`
  - Users can specify a tag which, when encountered (or tag greater than it is encountered)  will have the same effect as encountering the PixelData tag with `ReadOptions.DropPixelData` set to true