### PR TITLE
Replace vlog with stdlib log

### DIFF
--- a/dicom.go
+++ b/dicom.go
@@ -5,11 +5,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/grailbio/go-dicom/dicomio"
 	"github.com/grailbio/go-dicom/dicomtag"
-	"v.io/x/lib/vlog"
 )
 
 // GoDICOMImplementationClassUIDPrefix defines the UID prefix for
@@ -107,7 +107,7 @@ func ReadDataSet(in io.Reader, bytes int64, options ReadOptions) (*DataSet, erro
 		startLen := buffer.Len()
 		elem := ReadElement(buffer, options)
 		if buffer.Len() >= startLen { // Avoid silent infinite looping.
-			vlog.Fatalf("ReadElement failed to consume data: %d %d: %v", startLen, buffer.Len(), buffer.Error())
+			log.Fatalf("ReadElement failed to consume data: %d %d: %v", startLen, buffer.Len(), buffer.Error())
 		}
 		if elem == endOfDataElement {
 			// element is a pixel data and was dropped by options

--- a/dicom_test.go
+++ b/dicom_test.go
@@ -1,6 +1,7 @@
 package dicom_test
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -9,13 +10,12 @@ import (
 	"github.com/grailbio/go-dicom/dicomuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"v.io/x/lib/vlog"
 )
 
 func mustReadFile(path string, options dicom.ReadOptions) *dicom.DataSet {
 	data, err := dicom.ReadDataSetFromFile(path, options)
 	if err != nil {
-		vlog.Fatalf("%s: failed to read: %v", path, err)
+		log.Fatalf("%s: failed to read: %v", path, err)
 	}
 	return data
 }
@@ -26,7 +26,7 @@ func TestAllFiles(t *testing.T) {
 	names, err := dir.Readdirnames(0)
 	require.NoError(t, err)
 	for _, name := range names {
-		vlog.Infof("Reading %s", name)
+		log.Printf("Reading %s", name)
 		_ = mustReadFile("examples/"+name, dicom.ReadOptions{})
 	}
 }
@@ -40,7 +40,7 @@ func testWriteFile(t *testing.T, dcmPath, transferSyntaxUID string) {
 	for i := range data.Elements {
 		if data.Elements[i].Tag == dicomtag.TransferSyntaxUID {
 			newElem := dicom.MustNewElement(dicomtag.TransferSyntaxUID, transferSyntaxUID)
-			vlog.Infof("Setting transfer syntax UID from %v to %v",
+			log.Printf("Setting transfer syntax UID from %v to %v",
 				data.Elements[i].MustGetString(), newElem.MustGetString())
 			data.Elements[i] = newElem
 		}

--- a/dicomio/buffer_test.go
+++ b/dicomio/buffer_test.go
@@ -45,7 +45,7 @@ func TestBasic(t *testing.T) {
 	}
 	// Read past the buffer. It should flag an error
 	if _ = d.ReadByte(); d.Error() == nil {
-		t.Errorf("Error %v %v", d.Error())
+		t.Errorf("Error %v", d.Error())
 	}
 }
 

--- a/dicomio/charset.go
+++ b/dicomio/charset.go
@@ -1,9 +1,10 @@
 package dicomio
 
 import (
+	"log"
+
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/htmlindex"
-	"v.io/x/lib/vlog"
 )
 
 // CodingSystem defines how a []byte is translated into a utf8 string.
@@ -84,15 +85,15 @@ func ParseSpecificCharacterSet(encodingNames []string) (CodingSystem, error) {
 	var decoders []*encoding.Decoder
 	for _, name := range encodingNames {
 		var c *encoding.Decoder
-		vlog.VI(2).Infof("Using coding system %s", name)
+		log.Printf("Using coding system %s", name)
 		if htmlName, ok := htmlEncodingNames[name]; !ok {
 			// TODO(saito) Support more encodings.
-			vlog.Errorf("Unknown character set '%s'. Assuming utf-8", encodingNames[0])
+			log.Printf("Unknown character set '%s'. Assuming utf-8", encodingNames[0])
 		} else {
 			if htmlName != "" {
 				d, err := htmlindex.Get(htmlName)
 				if err != nil {
-					vlog.Fatalf("Encoding name %s (for %s) not found", name, htmlName)
+					log.Fatalf("Encoding name %s (for %s) not found", name, htmlName)
 				}
 				c = d.NewDecoder()
 			}

--- a/dicomio/transfersyntax.go
+++ b/dicomio/transfersyntax.go
@@ -3,9 +3,9 @@ package dicomio
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 
 	"github.com/grailbio/go-dicom/dicomuid"
-	"v.io/x/lib/vlog"
 )
 
 // Standard list of transfer syntaxes.
@@ -65,7 +65,7 @@ func ParseTransferSyntaxUID(uid string) (bo binary.ByteOrder, implicit IsImplici
 	case dicomuid.ExplicitVRBigEndian:
 		return binary.BigEndian, ExplicitVR, nil
 	default:
-		vlog.Fatal(canonical, uid)
+		log.Fatal(canonical, uid)
 		return binary.BigEndian, ExplicitVR, nil
 	}
 }

--- a/dicomtag/tag.go
+++ b/dicomtag/tag.go
@@ -8,10 +8,9 @@ package dicomtag
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
-
-	"v.io/x/lib/vlog"
 )
 
 // Tag is a <group, element> tuple that identifies an element type in a DICOM
@@ -158,7 +157,7 @@ func Find(tag Tag) (TagInfo, error) {
 func MustFind(tag Tag) TagInfo {
 	e, err := Find(tag)
 	if err != nil {
-		vlog.Fatalf("tag %v not found: %s", tag, err)
+		log.Fatalf("tag %v not found: %s", tag, err)
 	}
 	return e
 }

--- a/dicomuid/uid.go
+++ b/dicomuid/uid.go
@@ -7,8 +7,7 @@ package dicomuid
 
 import (
 	"fmt"
-
-	"v.io/x/lib/vlog"
+	"log"
 )
 
 type UIDType string
@@ -479,7 +478,7 @@ func Lookup(uid string) (UIDInfo, error) {
 func MustLookup(uid string) UIDInfo {
 	e, err := Lookup(uid)
 	if err != nil {
-		vlog.Fatal(err)
+		log.Fatal(err)
 	}
 	return e
 }

--- a/dicomutil/dicomutil.go
+++ b/dicomutil/dicomutil.go
@@ -23,7 +23,7 @@ func main() {
 	path := flag.Arg(0)
 	data, err := dicom.ReadDataSetFromFile(path, dicom.ReadOptions{DropPixelData: !*extractImages})
 	if data == nil {
-		log.Panic("Error reading %s: %v", path, err)
+		log.Panicf("Error reading %s: %v", path, err)
 	}
 	log.Printf("Error reading %s: %v", path, err)
 	if *printMetadata {

--- a/element.go
+++ b/element.go
@@ -6,11 +6,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/grailbio/go-dicom/dicomio"
 	"github.com/grailbio/go-dicom/dicomtag"
-	"v.io/x/lib/vlog"
 )
 
 // Constants
@@ -137,7 +137,7 @@ func NewElement(tag dicomtag.Tag, values ...interface{}) (*Element, error) {
 func MustNewElement(tag dicomtag.Tag, values ...interface{}) *Element {
 	elem, err := NewElement(tag, values...)
 	if err != nil {
-		vlog.Fatalf("Failed to create element with tag %v: %v", tag, err)
+		log.Fatalf("Failed to create element with tag %v: %v", tag, err)
 	}
 	return elem
 }
@@ -425,7 +425,7 @@ func ParseFileHeader(d *dicomio.Decoder) []*Element {
 			break
 		}
 		metaElems = append(metaElems, elem)
-		vlog.VI(2).Infof("Meta elem: %v, len %v", elem.String(), d.Len())
+		log.Printf("Meta elem: %v, len %v", elem.String(), d.Len())
 	}
 	return metaElems
 }
@@ -504,7 +504,7 @@ func ReadElement(d *dicomio.Decoder, options ReadOptions) *Element {
 			var image PixelDataInfo
 			image.Offsets = readBasicOffsetTable(d) // TODO(saito) Use the offset table.
 			if len(image.Offsets) > 1 {
-				vlog.Infof("Warning: multiple images not supported yet. Combining them into a byte sequence: %v", image.Offsets)
+				log.Printf("Warning: multiple images not supported yet. Combining them into a byte sequence: %v", image.Offsets)
 			}
 			for d.Len() > 0 {
 				chunk, endOfItems := readRawItem(d)
@@ -518,7 +518,7 @@ func ReadElement(d *dicomio.Decoder, options ReadOptions) *Element {
 			}
 			data = append(data, image)
 		} else {
-			vlog.Errorf("Warning: defined-length pixel data not supported: tag %v, VR=%v, VL=%v", tag.String(), vr, vl)
+			log.Printf("Warning: defined-length pixel data not supported: tag %v, VR=%v, VL=%v", tag.String(), vr, vl)
 			var image PixelDataInfo
 			image.Frames = append(image.Frames, d.ReadBytes(int(vl)))
 			data = append(data, image)

--- a/queryretrieve.go
+++ b/queryretrieve.go
@@ -2,12 +2,12 @@ package dicom
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 
 	"github.com/gobwas/glob"
 	"github.com/grailbio/go-dicom/dicomtag"
-	"v.io/x/lib/vlog"
 )
 
 func querySequence(elem *Element, f *Element) (match bool, err error) {
@@ -100,7 +100,7 @@ func queryElement(elem *Element, f *Element) (match bool, err error) {
 			return ok, nil
 		}
 	default:
-		vlog.Fatalf("Unknown data: %v", f)
+		log.Fatalf("Unknown data: %v", f)
 	}
 	return false, nil
 }

--- a/writer.go
+++ b/writer.go
@@ -4,11 +4,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/grailbio/go-dicom/dicomio"
 	"github.com/grailbio/go-dicom/dicomtag"
-	"v.io/x/lib/vlog"
 )
 
 // WriteFileHeader produces a DICOM file header. metaElems[] is be a list of
@@ -131,7 +131,7 @@ func WriteElement(e *dicomio.Encoder, elem *Element) {
 					dicomtag.DebugString(elem.Tag), vr, entry.VR)
 				return
 			}
-			vlog.VI(1).Infof("VR value mismatch for tag %s. Element.VR=%v, but DICOM standard defines VR to be %v (continuing)",
+			log.Printf("VR value mismatch for tag %s. Element.VR=%v, but DICOM standard defines VR to be %v (continuing)",
 				dicomtag.DebugString(elem.Tag), vr, entry.VR)
 		}
 	}


### PR DESCRIPTION
As discussed on #5, this is what replacing vlog wit the standard library log looks like. All flags have disappeared, as expected.

I'd still like to remove these logs completely and return errors where appropriate but that's still under discussion and if it happens it will be a separate PR.